### PR TITLE
Change `cencentrate` to `concentrate`

### DIFF
--- a/erdot/dTemplate.py
+++ b/erdot/dTemplate.py
@@ -5,7 +5,7 @@ digraph G {
     graph [
         nodesep=0.5;
         rankdir="LR";
-        cencentrate=true;
+        concentrate=true;
         splines="spline";
         fontname="Helvetica";
         pad="0.2,0.2",

--- a/example/example.dot
+++ b/example/example.dot
@@ -3,7 +3,7 @@ digraph G {
     graph [
         nodesep=0.5;
         rankdir="LR";
-        cencentrate=true;
+        concentrate=true;
         splines="spline";
         fontname="Helvetica";
         pad="0.2,0.2",


### PR DESCRIPTION
... in dTemplate.py and example/example.dot

Thanks for the great tool! This PR just fixes a small typo I noticed in the produced `dot` output and traced back to the template; I don't believe `cencentrate` is a valid graphviz dot language attribute